### PR TITLE
Doorbell like a switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,9 @@ the accessories folder. See for example [switch](src/accessories/switch.js) or [
 the accessories factory in `accessories.js` aware of you new device type. The factory receives the entire response of the get-sensors call from the HomeWizard which lists all devices.
 
 # Changelog
+- 0.0.56 - Doorbell like a switch
+- 0.0.55 - eslint reactivation and push request activated by default
+- 0.0.54 - bump version
 - 0.0.53 - Push mode and doorbell support
 - 0.0.52 - Added api call response logging for debug level
 - 0.0.51 - Fix issue when there are no scenes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-homewizard",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "description": "Plugin for Homebridge to communicate with HomeWizard",
   "author": "Raymond de Wit",
   "license": "ISC",

--- a/src/accessories/doorbell.js
+++ b/src/accessories/doorbell.js
@@ -7,8 +7,8 @@ export class HomeWizardDoorbell extends HomeWizardBaseAccessory {
 
   setupServices() {
     // Setup services
-    const doorbellService = new this.hap.Service.Doorbell();
-    this.programmableSwitchEvent = doorbellService.getCharacteristic(this.hap.Characteristic.ProgrammableSwitchEvent);
+    const doorbellService = new this.hap.Service.Switch();
+    this.programmableSwitchEvent = doorbellService.getCharacteristic(this.hap.Characteristic.On);
     this.programmableSwitchEvent.on('get', this.getProgrammableSwitchEvent.bind(this));
 
     this.services.push(doorbellService);
@@ -17,10 +17,13 @@ export class HomeWizardDoorbell extends HomeWizardBaseAccessory {
   getProgrammableSwitchEvent(callback) {
     this.api.getStatus(this.id, 'kakusensors').then(sensor => {
 
-      const pressed = this.recentDetection(sensor) ? 1 : 0;
+      const pressed = this.recentDetection(sensor);
 
-      if (pressed === 1) {
+      if (pressed) {
         this.log(`Retreived button pressed on: ${this.name}`);
+        setTimeout(function (me) {
+          me.programmableSwitchEvent.setValue(false);
+        }, 2000, this);
       }
 
       this.programmableSwitchEvent.setValue(pressed);


### PR DESCRIPTION
Since 10 days, the Apple Home app does not support the doorbell service alone. This version show the doorbell like an ordinary switch opened during 2 seconds.