### PR TITLE
Adding 868Mhz smokedetectors

### DIFF
--- a/src/accessories.js
+++ b/src/accessories.js
@@ -84,6 +84,9 @@ export class AccessoriesFactory {
         case 'smoke':
           this._instantiateAccessory(HomeWizardSmokeSensor, kakusensor);
           break;
+        case 'smoke868':
+          this._instantiateAccessory(HomeWizardSmokeSensor, kakusensor);
+          break;
         case 'contact':
           this._instantiateAccessory(HomeWizardContactSensor, kakusensor);
           break;


### PR DESCRIPTION
I have two smokedetectors in Homewizard that use the 868Mhz frequency and they are listed in the get-sensors overview as 'smoke868' instead of just 'smoke'. To allow them to be supported in this homebridge plugin, I made the above change to the code. Very simple case addition.